### PR TITLE
fix: use whitenoise to properly serve the media assets on both prod and dev

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,4 +11,5 @@ dependencies = [
     "gunicorn>=23.0.0",
     "pre-commit>=4.2.0",
     "python-dotenv>=1.1.0",
+    "whitenoise>=6.9.0",
 ]

--- a/speedierwatch/settings.py
+++ b/speedierwatch/settings.py
@@ -47,6 +47,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "whitenoise.runserver_nostatic",  
     "study.apps.StudyConfig",
     "crispy_forms",
     "crispy_bootstrap5",
@@ -54,6 +55,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware", 
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
@@ -76,6 +78,7 @@ TEMPLATES = [
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
                 "django.template.context_processors.static",
+                "django.template.context_processors.media",
             ],
         },
     },
@@ -130,11 +133,18 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/5.0/howto/static-files/
 
 STATIC_URL = "static/"
-STATICFILES_DIRS = []
-STATIC_ROOT = None
+STATICFILES_DIRS = [BASE_DIR / "static"]
+STATIC_ROOT = BASE_DIR / "staticfiles"
 
 MEDIA_URL = "media/"
 MEDIA_ROOT = BASE_DIR / "media"
+
+# WhiteNoise configuration
+WHITENOISE_USE_FINDERS = True
+# Don't set WHITENOISE_ROOT to MEDIA_ROOT as that's not its intended use
+# WHITENOISE_ROOT should be for specific files to serve at root URL
+WHITENOISE_INDEX_FILE = False
+STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.0/ref/settings/#default-auto-field

--- a/speedierwatch/urls.py
+++ b/speedierwatch/urls.py
@@ -25,6 +25,6 @@ urlpatterns = [
     path("", include("study.urls")),
 ]
 
-# Only add these URL patterns during development
-if settings.DEBUG:
-    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+# No longer needed as WhiteNoise will handle media files
+# if settings.DEBUG:
+#     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/study/views.py
+++ b/study/views.py
@@ -1,6 +1,5 @@
 from django.shortcuts import render, redirect
 from django.contrib import messages
-from django.http import FileResponse
 from .models import Participant, QuizResponse
 from .forms import ParticipantForm, QuizForm
 import random
@@ -39,11 +38,6 @@ def video(request):
             "video_speed": "1" if participant.treatment_group == 1 else "2",
         },
     )
-
-
-def serve_video(request):
-    video_path = os.path.join(settings.MEDIA_ROOT, 'chronomapping.mp4')
-    return FileResponse(open(video_path, 'rb'), content_type='video/mp4')
 
 
 def invalidate_participant(request):

--- a/templates/study/video.html
+++ b/templates/study/video.html
@@ -44,7 +44,7 @@
 
                 <div class="ratio ratio-16x9 mb-4 position-relative video-container">
                     <video id="studyVideo" class="rounded" preload="auto">
-                        <source src="/media/chronomapping.mp4" type="video/mp4">
+                        <source src="{% static 'videos/chronomapping.mp4' %}" type="video/mp4">
                         Your browser does not support the video tag.
                     </video>
                     <button id="playButton" class="btn btn-primary position-absolute top-50 start-50 translate-middle">

--- a/uv.lock
+++ b/uv.lock
@@ -186,6 +186,7 @@ dependencies = [
     { name = "gunicorn" },
     { name = "pre-commit" },
     { name = "python-dotenv" },
+    { name = "whitenoise" },
 ]
 
 [package.metadata]
@@ -196,6 +197,7 @@ requires-dist = [
     { name = "gunicorn", specifier = ">=23.0.0" },
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
+    { name = "whitenoise", specifier = ">=6.9.0" },
 ]
 
 [[package]]
@@ -228,4 +230,13 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/56/2c/444f465fb2c65f40c3a104fd0c495184c4f2336d65baf398e3c75d72ea94/virtualenv-20.31.2.tar.gz", hash = "sha256:e10c0a9d02835e592521be48b332b6caee6887f332c111aa79a09b9e79efc2af", size = 6076316 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/40/b1c265d4b2b62b58576588510fc4d1fe60a86319c8de99fd8e9fec617d2c/virtualenv-20.31.2-py3-none-any.whl", hash = "sha256:36efd0d9650ee985f0cad72065001e66d49a6f24eb44d98980f630686243cf11", size = 6057982 },
+]
+
+[[package]]
+name = "whitenoise"
+version = "6.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/cf/c15c2f21aee6b22a9f6fc9be3f7e477e2442ec22848273db7f4eb73d6162/whitenoise-6.9.0.tar.gz", hash = "sha256:8c4a7c9d384694990c26f3047e118c691557481d624f069b7f7752a2f735d609", size = 25920 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b2/2ce9263149fbde9701d352bda24ea1362c154e196d2fda2201f18fc585d7/whitenoise-6.9.0-py3-none-any.whl", hash = "sha256:c8a489049b7ee9889617bb4c274a153f3d979e8f51d2efd0f5b403caf41c57df", size = 20161 },
 ]


### PR DESCRIPTION
This pull request introduces several updates to improve static file handling, streamline media file serving, and clean up unused code in the project. The most significant changes include integrating WhiteNoise for static file management, updating settings for static and media files, and removing redundant code for serving media files during development.

### Static file handling improvements:
* Added `whitenoise` as a dependency in `pyproject.toml` and integrated it into the Django project by adding `whitenoise.runserver_nostatic` to `INSTALLED_APPS` and `WhiteNoiseMiddleware` to `MIDDLEWARE` in `speedierwatch/settings.py`. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R14) [[2]](diffhunk://#diff-2ca26e111ae98738ce748516f64be00f7ab33b38c805c9671f57dfa48baba971R50-R58)
* Configured static and media file paths in `speedierwatch/settings.py`. Added `STATICFILES_DIRS`, `STATIC_ROOT`, and `MEDIA_ROOT`, and configured WhiteNoise-specific settings such as `STATICFILES_STORAGE` and `WHITENOISE_USE_FINDERS`.

### Media file serving updates:
* Updated the video source in `templates/study/video.html` to use the `{% static %}` template tag for serving media files through WhiteNoise instead of relying on the `/media/` URL.
* Removed the `serve_video` function and related imports from `study/views.py`, as WhiteNoise now handles media file serving. [[1]](diffhunk://#diff-603648929496aad7b31e68c178c17bcd260808851bc7d095cfac28279f8d00acL3) [[2]](diffhunk://#diff-603648929496aad7b31e68c178c17bcd260808851bc7d095cfac28279f8d00acL44-L48)
* Removed the conditional `urlpatterns` for serving media files during development in `speedierwatch/urls.py`, as WhiteNoise eliminates the need for this logic.